### PR TITLE
Added function to simplify listening for process interrupt os signal

### DIFF
--- a/utils/os.go
+++ b/utils/os.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"os"
+	"os/signal"
+)
+
+// OnInterrupt returns a channel which receives the SIGINT system signal.
+func OnInterrupt() chan os.Signal {
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+	return sigint
+}


### PR DESCRIPTION
Example usage:
```golang
func main() {
  fmt.Println("Waiting for SIGINT...")
  <-OnInterrupt()
  fmt.Println("Process exiting")
}
```